### PR TITLE
Fix nested records route

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,22 +69,13 @@ const routes = [
       // Módulo de Registro Contable
       {
         path: 'basicAccountingRecordsBook',
-        // name: 'BasicAccountingRecordsBook',
+        name: 'BasicAccountingRecordsBook',
         component: () => import('@/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue'),
-        children: [
-          {
-            path: '',
-            name: 'BasicAccountingRecordsBook',
-            component: () => import('@/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue'),
-
-          },
-          {
-            path: ':registerId',
-            name: 'DetailsRecords',
-            // TODO arreglar esto porque no funciona para RecordsDetails.vue. Por el contrario, lo que está cargando es BasicAccountingRecordsWrapper.vue y está cargando a '@/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue'),
-            component: () => import('@/views/basicAccountingRecords/RecordsDetails.vue'),
-          }
-        ]
+      },
+      {
+        path: 'basicAccountingRecordsBook/:registerId',
+        name: 'DetailsRecords',
+        component: () => import('@/views/basicAccountingRecords/RecordsDetails.vue'),
       },
 
       // Módulo de Caja Diaria


### PR DESCRIPTION
## Summary
- fix nested routes for accounting records so details page works

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e806ea8a0832fa61b3c6ec67345c9